### PR TITLE
Write free-format TOUGH input file

### DIFF
--- a/toughio/__init__.py
+++ b/toughio/__init__.py
@@ -13,9 +13,11 @@ from .__about__ import (
     __license__,
 )
 from . import mesh
+from . import model
 
 __all__ = [
     "mesh",
+    "model",
     "__version__",
     "__author__",
     "__author_email__",

--- a/toughio/model/__init__.py
+++ b/toughio/model/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+"""
+Author: Keurfon Luu <keurfonluu@lbl.gov>
+License: MIT
+"""
+
+from .io import (
+    Parameters,
+    new,
+    write,
+)
+
+__all__ = [
+    "Parameters",
+    "new",
+    "write",
+]

--- a/toughio/model/io/__init__.py
+++ b/toughio/model/io/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+"""
+Author: Keurfon Luu <keurfonluu@lbl.gov>
+License: MIT
+"""
+
+from .common import (
+    Parameters,
+    new,
+)
+from .write import write
+
+__all__ = [
+    "Parameters",
+    "new",
+    "write",
+]

--- a/toughio/model/io/common.py
+++ b/toughio/model/io/common.py
@@ -48,7 +48,7 @@ _options = {
     "w_upstream": None,
     "w_newton": None,
     "derivative_factor": None,
-    "incon": [ None ] * 4,
+    "incon": [ None for _ in range(4) ],
 }
 
 _Parameters = {

--- a/toughio/model/io/common.py
+++ b/toughio/model/io/common.py
@@ -10,6 +10,8 @@ from functools import wraps
 
 __all__ = [
     "Parameters",
+    "options",
+    "generators",
     "default",
     "eos",
     "header",
@@ -24,13 +26,14 @@ _mop = { k+1: v for k, v in enumerate([
     None, None, None, None, 3, None, None, None, 
 ]) }
 
+_select = { k+1: None for k in range(16) }
+
 _options = {
     "n_iteration": None,
     "n_cycle": None,
     "n_second": None,
     "n_cycle_print": None,
     "verbosity": None,
-    "MOP": dict(_mop),
     "temperature_dependance_gas": None,
     "effective_strength_vapor": None,
     "t_ini": None,
@@ -55,16 +58,29 @@ _Parameters = {
     "isothermal": False,
     "nover": False,
     "rocks": {},
-    "options": dict(_options),
+    "options": {},
+    "extra_options": dict(_mop),
+    "selections": dict(_select),
+    "extra_selections": None,
     "solver": None,
+    "generators": {},
     "times": None,
-    "foft": None,
-    "coft": None,
-    "goft": None,
+    "element_history": None,
+    "connection_history": None,
+    "generator_history": None,
     "default": {},
 }
 
+options = dict(_options)
+
 Parameters = dict(_Parameters)
+
+generators = {
+    "type": None,
+    "rate": None,
+    "specific_enthalpy": None,
+    "layer_thickness": None,
+}
 
 default = {
     "density": None,
@@ -123,7 +139,8 @@ def new():
     Parameters.update(_Parameters)
     Parameters["rocks"] = {}
     Parameters["options"].update(_options)
-    Parameters["options"]["MOP"].update(_mop)
+    Parameters["extra_options"].update(_mop)
+    Parameters["selections"].update(_select)
 
 
 def block(keyword, multi = False):

--- a/toughio/model/io/common.py
+++ b/toughio/model/io/common.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+
+"""
+Author: Keurfon Luu <keurfonluu@lbl.gov>
+License: MIT
+"""
+
+import numpy as np
+from functools import wraps
+
+__all__ = [
+    "Parameters",
+    "default",
+    "eos",
+    "header",
+    "new",
+    "block",
+]
+
+
+_mop = { k+1: v for k, v in enumerate([
+    None, 0, 0, 0, None, 0, 2, None,
+    0, 0, 0, 0, 0, None, None, 4,
+    None, None, None, None, 3, None, None, None, 
+]) }
+
+_options = {
+    "n_iteration": None,
+    "n_cycle": None,
+    "n_second": None,
+    "n_cycle_print": None,
+    "verbosity": None,
+    "MOP": dict(_mop),
+    "temperature_dependance_gas": None,
+    "effective_strength_vapor": None,
+    "t_ini": None,
+    "t_max": None,
+    "t_step": None,
+    "t_step_max": None,
+    "t_reduce_factor": None,
+    "gravity": 9.81,
+    "mesh_scale_factor": None,
+    "eps1": None,
+    "eps2": None,
+    "w_upstream": None,
+    "w_newton": None,
+    "derivative_factor": None,
+    "incon": [ None ] * 4,
+}
+
+_Parameters = {
+    "title": "",
+    "eos": "",
+    "flac": False,
+    "isothermal": False,
+    "nover": False,
+    "rocks": {},
+    "options": dict(_options),
+    "solver": None,
+    "times": None,
+    "foft": None,
+    "coft": None,
+    "goft": None,
+    "default": {},
+}
+
+Parameters = dict(_Parameters)
+
+default = {
+    "density": None,
+    "porosity": None,
+    "permeability": None,
+    "conductivity": None,
+    "specific_heat": None,
+    "compressibility": None,
+    "expansivity": None,
+    "conductivity_dry": None,
+    "tortuosity": None,
+    "b_coeff": None,
+    "xkd3": None,
+    "xkd4": None,
+    "relative_permeability": {
+        "id": None,
+        "parameters": [],
+    },
+    "capillary_pressure": {
+        "id": None,
+        "parameters": [],
+    },
+    "permeability_law": {
+        "id": 1,
+        "parameters": [],
+    },
+    "equivalent_pore_pressure": {
+        "id": 3,
+        "parameters": [ 0.2684e8, -0.1991e8, 0.3845 ],
+    },
+}
+
+eos = {
+    "eos1": [],
+    "eos2": [],
+    "eos3": [],
+    "eos4": [],
+    "eos5": [],
+    "eos7": [],
+    "eos8": [],
+    "eos9": [],
+    "eosmvoc": [],
+    "eoswasg": [],
+    "eco2n": [ 3, 4, 3, 6 ],
+    "eco2n_v2": [ 3, 4, 3, 6 ],
+    "eco2m": [ 3, 4, 3, 6 ],
+}
+
+header = "----1----*----2----*----3----*----4----*----5----*----6----*----7----*----8"
+
+
+def new():
+    """
+    Reset parameter values to default.
+    """
+    Parameters.update(_Parameters)
+    Parameters["rocks"] = {}
+    Parameters["options"].update(_options)
+    Parameters["options"]["MOP"].update(_mop)
+
+
+def block(keyword, multi = False):
+    """
+    Decorator for block writing functions.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            out = [ "{:5}{}\n".format(keyword, header) ]
+            out += func(*args, **kwargs)
+            out += [ "\n" ] if multi else []
+            return out
+        return wrapper
+    return decorator

--- a/toughio/model/io/write.py
+++ b/toughio/model/io/write.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+
+"""
+Author: Keurfon Luu <keurfonluu@lbl.gov>
+License: MIT
+"""
+
+import numpy as np
+
+from .common import (
+    block,
+    default,
+)
+
+__all__ = [
+    "write",
+]
+
+
+def write(filename = "INFILE"):
+    """
+    Write TOUGH input file.
+
+    Parameters
+    ----------
+    filename : str, optional, default 'INFILE'
+        Output file name.
+    """
+    assert isinstance(filename, str)
+
+    # Import current parameter settings
+    from .common import Parameters, eos
+
+    # Check that EOS is defined (for block MULTI)
+    if Parameters["eos"] not in eos.keys():
+        raise ValueError(
+            "EOS '{}' is unknown or not supported.".format(Parameters["eos"])
+        )
+
+    # Define input file contents
+    out = [ "* {:78}\n".format(Parameters["title"]) ]
+    out += _write_rocks(Parameters)
+    if Parameters["flac"]:
+        out += _write_flac(Parameters)
+    out += _write_multi(Parameters)
+    out += _write_start()
+    out += _write_param(Parameters)
+    return out
+
+
+def _format_data(data):
+    """
+    Return a list of strings given input data and formats.
+    """
+    def to_str(x, fmt):
+        x = "" if x is None or x == "" else x
+        if isinstance(x, str):
+            return fmt.replace("g", "").replace("e", "").format(x)
+        else:
+            return fmt.format(x)
+    return [ to_str(x, fmt) for x, fmt in data ]
+
+
+def _write_record(data):
+    """
+    Return a list with a single string.
+    """
+    return [ "{:80}\n".format("".join(data)) ]
+
+
+def _add_record(data, id_fmt = "{:>5g}     "):
+    """
+    Return a list with a single string for additional records.
+    """
+    n = len(data["parameters"])
+    rec = [ ( data["id"], id_fmt ) ]
+    rec += [ ( v, "{:>10.3e}" ) for v in data["parameters"][:min(n, 7)] ]
+    return _write_record(_format_data(rec))
+
+
+@block("ROCKS", multi = True)
+def _write_rocks(Parameters):
+    """
+    Block ROCKS.
+    """
+    out = []
+    for k, v in Parameters["rocks"].items():
+        # Load data
+        tmp = default.copy()
+        tmp.update(Parameters["default"])
+        tmp.update(v)
+
+        # Number of additional lines to write per rock
+        nad = 0
+        nad += 1 if tmp["relative_permeability"]["id"] is not None else 0
+        nad += 1 if tmp["capillary_pressure"]["id"] is not None else 0
+
+        # Permeability
+        per = tmp["permeability"]
+        per = [ per ] * 3 if isinstance(per, float) else per
+        assert isinstance(per, (list, tuple, np.ndarray)) and len(per) == 3
+
+        # Record 1
+        out += _write_record(_format_data([
+            ( k, "{:5.5}" ),
+            ( nad if nad else None, "{:>5g}" ),
+            ( tmp["density"], "{:>10.4e}" ) ,
+            ( tmp["porosity"], "{:>10.4e}" ),
+            ( per[0], "{:>10.4e}" ),
+            ( per[1], "{:>10.4e}" ),
+            ( per[2], "{:>10.4e}" ),
+            ( tmp["conductivity"], "{:>10.4e}" ),
+            ( tmp["specific_heat"], "{:>10.4e}" ),
+        ]))
+
+        # Record 2
+        out += _write_record(_format_data([
+            ( tmp["compressibility"], "{:>10.4e}" ),
+            ( tmp["expansivity"], "{:>10.4e}" ),
+            ( tmp["conductivity_dry"], "{:>10.4e}" ),
+            ( tmp["tortuosity"], "{:>10.4e}" ),
+            ( tmp["b_coeff"], "{:>10.4e}" ),
+            ( tmp["xkd3"], "{:>10.4e}" ),
+            ( tmp["xkd4"], "{:>10.4e}" ),
+        ]))
+
+        # Relative permeability
+        out += _add_record(tmp["relative_permeability"]) if nad >= 1 else []
+
+        # Capillary pressure
+        out += _add_record(tmp["capillary_pressure"]) if nad >= 2 else []
+    return out
+
+
+@block("FLAC", multi = True)
+def _write_flac(Parameters):
+    """
+    Block FLAC.
+    """
+    out = [ "\n" ]
+    for v in Parameters["rocks"].values():
+        # Load data
+        tmp = default.copy()
+        tmp.update(Parameters["default"])
+        tmp.update(v)
+
+        # Permeability law
+        out += _add_record(tmp["permeability_law"], "{:>10g}")
+
+        # Equivalent pore pressure
+        out += _add_record(tmp["equivalent_pore_pressure"])
+    return out
+
+
+@block("MULTI", multi = False)
+def _write_multi(Parameters):
+    """
+    Block MULTI.
+    """
+    from .common import eos
+    out = eos[Parameters["eos"]].copy()
+    out[1] -= 1 if Parameters["isothermal"] else 0
+    return [ ("{:>5d}"*4 + "\n").format(*out) ]
+
+
+@block("START", multi = False)
+def _write_start():
+    """
+    Block START.
+    """
+    from .common import header
+    out = "{:5}{}\n".format("----*", header)
+    return [ out[:11] + "MOP: 123456789*123456789*1234" + out[40:] ]
+
+
+@block("PARAM", multi = False)
+def _write_param(Parameters):
+    """
+    Block PARAM.
+    """
+    out = []
+
+    # Load data
+    data = Parameters["options"]
+
+    # Record 1
+    mop = _format_data([ ( data["MOP"][k], "{:>1g}" )
+                            for k in sorted(data["MOP"].keys()) ])
+    out += _write_record(_format_data([
+        ( data["n_iteration"], "{:>2g}" ),
+        ( data["verbosity"], "{:>2g}" ),
+        ( data["n_cycle"], "{:>4g}" ),
+        ( data["n_second"], "{:>4g}" ),
+        ( data["n_cycle_print"], "{:>4g}" ),
+        ( "{}".format("".join(mop)), "{:>24}" ),
+        ( None, "{:>10}" ),
+        ( data["temperature_dependance_gas"], "{:>10.4e}" ),
+        ( data["effective_strength_vapor"], "{:>10.4e}" ),
+    ]))
+
+    # Record 2
+    out += _write_record(_format_data([
+        ( data["t_ini"], "{:>10.4e}" ),
+        ( data["t_max"], "{:>10.4e}" ),
+        ( data["t_step"], "{:>10.4e}" ),
+        ( data["t_step_max"], "{:>10.4e}" ),
+        ( None, "{:>10g}" ),
+        ( data["gravity"], "{:>10.4e}" ),
+        ( data["t_reduce_factor"], "{:>10.4e}" ),
+        ( data["mesh_scale_factor"], "{:>10.4e}" ),
+    ]))
+
+    # Record 3
+    out += _write_record(_format_data([
+        ( data["eps1"], "{:>10.4e}" ),
+        ( data["eps2"], "{:>10.4e}" ),
+        ( None, "{:>10.4e}" ),
+        ( data["w_upstream"], "{:>10.4e}" ),
+        ( data["w_newton"], "{:>10.4e}" ),
+        ( data["derivative_factor"], "{:>10.4e}" ),
+    ]))
+
+    # Record 4
+    n = len(data["incon"])
+    out += _write_record(_format_data([
+        ( i, "{:>20.4e}" ) for i in data["incon"][:min(n, 4)]
+    ]))
+    return out

--- a/toughio/model/io/write.py
+++ b/toughio/model/io/write.py
@@ -27,7 +27,13 @@ def write(filename = "INFILE"):
         Output file name.
     """
     assert isinstance(filename, str)
+    
+    with open(filename, "w") as f:
+        for record in write_buffer():
+            f.write(record)
 
+
+def write_buffer():
     # Import current parameter settings
     from .common import Parameters, eos
 


### PR DESCRIPTION
This PR add basic function to write TOUGH input files as free-format using Python dictionaries similar to JSON format. So far, only most common blocks and options (that I use) are written. I will gradually add new blocks and options.

**Note**: this PR only support EOS ``"eco2n"``, ``"eco2n_v2"`` and ``"eco2m"``. More EOS are to be added too.