### PR TITLE
Fix cylindric mesh pickling error

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/meshmaker/_cylindric_grid.py
+++ b/toughio/meshmaker/_cylindric_grid.py
@@ -8,6 +8,64 @@ __all__ = [
 ]
 
 
+class CylindricMesh(Mesh):
+    """Cylindric mesh.
+
+    This class is only intended to be used as output of :function:`cylindric_grid`.
+
+    Note
+    ----
+    This class inherits from :class:`toughio.Mesh` but overwrites how face areas
+    and volumes are calculated.
+
+    """
+
+    def __init__(self, dr, dz, *args, **kwargs):
+        super(CylindricMesh, self).__init__(*args, **kwargs)
+        self._dr = dr
+        self._dz = dz
+
+    def _get_areas_heights(self):
+        """Return areas and heights of cells in mesh."""
+        nr, nz = len(self._dr), len(self._dz)
+        r2 = numpy.cumsum(self._dr) ** 2
+        areas = (
+            numpy.tile(numpy.concatenate(([r2[0]], r2[1:] - r2[:-1])), nz) * numpy.pi
+        )
+        heights = numpy.tile(self._dz[:, None], nr).ravel()
+
+        return areas, heights
+
+    @property
+    def face_areas(self):
+        """Areas of faces in mesh."""
+        nz = len(self._dz)
+        dr = numpy.concatenate(([0.0], self._dr))
+        perimeters_in = numpy.tile(numpy.cumsum(dr[:-1]), nz) * 2.0 * numpy.pi
+        perimeters_out = numpy.tile(numpy.cumsum(dr[1:]), nz) * 2.0 * numpy.pi
+        areas, heights = self._get_areas_heights()
+        sections = numpy.tile(self._dr, nz) * heights
+
+        return [
+            numpy.transpose(
+                [
+                    areas,
+                    areas,
+                    sections,
+                    perimeters_out * heights,
+                    sections,
+                    perimeters_in * heights,
+                ]
+            )
+        ]
+
+    @property
+    def volumes(self):
+        """Volumes of cell in mesh."""
+        areas, heights = self._get_areas_heights()
+        return [areas * heights]
+
+
 def cylindric_grid(dr, dz, origin_z=None, material="dfalt"):
     """Generate a cylindric mesh as a radial XZ structured grid.
 
@@ -28,65 +86,6 @@ def cylindric_grid(dr, dz, origin_z=None, material="dfalt"):
         Output cylindric mesh.
 
     """
-
-    class CylindricMesh(Mesh):
-        """Cylindric mesh.
-
-        This class is only intended to be used as output of :function:`cylindric_grid`.
-
-        Note
-        ----
-        This class inherits from :class:`toughio.Mesh` but overwrites how face
-        areas and volumes are calculated.
-
-        """
-
-        def __init__(self, dr, dz, *args, **kwargs):
-            super(CylindricMesh, self).__init__(*args, **kwargs)
-            self._dr = dr
-            self._dz = dz
-
-        def _get_areas_heights(self):
-            """Return areas and heights of cells in mesh."""
-            nr, nz = len(self._dr), len(self._dz)
-            r2 = numpy.cumsum(self._dr) ** 2
-            areas = (
-                numpy.tile(numpy.concatenate(([r2[0]], r2[1:] - r2[:-1])), nz)
-                * numpy.pi
-            )
-            heights = numpy.tile(self._dz[:, None], nr).ravel()
-
-            return areas, heights
-
-        @property
-        def face_areas(self):
-            """Areas of faces in mesh."""
-            nz = len(self._dz)
-            dr = numpy.concatenate(([0.0], self._dr))
-            perimeters_in = numpy.tile(numpy.cumsum(dr[:-1]), nz) * 2.0 * numpy.pi
-            perimeters_out = numpy.tile(numpy.cumsum(dr[1:]), nz) * 2.0 * numpy.pi
-            areas, heights = self._get_areas_heights()
-            sections = numpy.tile(self._dr, nz) * heights
-
-            return [
-                numpy.transpose(
-                    [
-                        areas,
-                        areas,
-                        sections,
-                        perimeters_out * heights,
-                        sections,
-                        perimeters_in * heights,
-                    ]
-                )
-            ]
-
-        @property
-        def volumes(self):
-            """Volumes of cell in mesh."""
-            areas, heights = self._get_areas_heights()
-            return [areas * heights]
-
     assert isinstance(dr, (list, tuple, numpy.ndarray))
     assert isinstance(dz, (list, tuple, numpy.ndarray))
     assert origin_z is None or isinstance(origin_z, (int, float))
@@ -99,7 +98,7 @@ def cylindric_grid(dr, dz, origin_z=None, material="dfalt"):
     origin_z = origin_z if origin_z is not None else -dz.sum()
 
     mesh = structured_grid(
-        dr, [1.0], dz, origin=[0.0, 0.0, origin_z], material=material
+        dr, [1.0], dz, origin=[0.0, -0.5, origin_z], material=material
     )
 
     return CylindricMesh(


### PR DESCRIPTION
**MeshMaker**
- Fixed: ``pickle`` cannot pickle objects defined in functions.