### PR TITLE
Various fixes and improvements for TOUGH inputs

### DIFF
--- a/test/test_input.py
+++ b/test/test_input.py
@@ -474,7 +474,7 @@ def test_diffu(write_read):
     n_phase = numpy.random.randint(8) + 1
     parameters_ref = {
         "n_phase": n_phase,
-        "diffusion": numpy.random.rand(2, n_phase),
+        "diffusion": numpy.random.rand(numpy.random.randint(5) + 1, n_phase),
     }
     parameters = write_read(parameters_ref)
 

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -196,48 +196,6 @@ def test_multi(write_read, isothermal):
     assert parameters_ref["isothermal"] == parameters["isothermal"]
 
 
-@pytest.mark.parametrize(
-    "write_read, num_floats",
-    [
-        (write_read_tough, None),
-        (write_read_tough, 8),
-        (write_read_json, None),
-        (write_read_json, 8),
-    ],
-)
-def test_selec(write_read, num_floats):
-    parameters_ref = {
-        "selections": {
-            "integers": {
-                k + 1: v for k, v in enumerate(numpy.random.randint(100, size=16))
-            },
-            "floats": (
-                numpy.random.rand(num_floats)
-                if num_floats is not None and num_floats <= 8
-                else numpy.random.rand(numpy.random.randint(100) + 1, numpy.random.randint(8) + 1)
-            ),
-        },
-    }
-    parameters_ref["selections"]["integers"][1] = (
-        len(parameters_ref["selections"]["floats"])
-        if numpy.ndim(parameters_ref["selections"]["floats"]) == 2
-        else 1
-    )
-    parameters = write_read(parameters_ref)
-
-    helpers.allclose_dict(
-        parameters_ref["selections"]["integers"], parameters["selections"]["integers"]
-    )
-    if "floats" in parameters["selections"].keys():
-        assert numpy.allclose(
-            parameters_ref["selections"]["floats"],
-            parameters["selections"]["floats"],
-            atol=1.0e-4,
-        )
-    else:
-        assert parameters_ref["selections"]["integers"][1] == 0
-
-
 @pytest.mark.parametrize("write_read", [write_read_tough, write_read_json])
 def test_solvr(write_read):
     parameters_ref = {
@@ -315,6 +273,48 @@ def test_param(write_read, t_steps, num_pvars):
         )
     else:
         assert not len(parameters_ref["default"]["initial_condition"])
+
+
+@pytest.mark.parametrize(
+    "write_read, num_floats",
+    [
+        (write_read_tough, None),
+        (write_read_tough, 8),
+        (write_read_json, None),
+        (write_read_json, 8),
+    ],
+)
+def test_selec(write_read, num_floats):
+    parameters_ref = {
+        "selections": {
+            "integers": {
+                k + 1: v for k, v in enumerate(numpy.random.randint(100, size=16))
+            },
+            "floats": (
+                numpy.random.rand(num_floats)
+                if num_floats is not None and num_floats <= 8
+                else numpy.random.rand(numpy.random.randint(100) + 1, numpy.random.randint(8) + 1)
+            ),
+        },
+    }
+    parameters_ref["selections"]["integers"][1] = (
+        len(parameters_ref["selections"]["floats"])
+        if numpy.ndim(parameters_ref["selections"]["floats"]) == 2
+        else 1
+    )
+    parameters = write_read(parameters_ref)
+
+    helpers.allclose_dict(
+        parameters_ref["selections"]["integers"], parameters["selections"]["integers"]
+    )
+    if "floats" in parameters["selections"].keys():
+        assert numpy.allclose(
+            parameters_ref["selections"]["floats"],
+            parameters["selections"]["floats"],
+            atol=1.0e-4,
+        )
+    else:
+        assert parameters_ref["selections"]["integers"][1] == 0
 
 
 @pytest.mark.parametrize(

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -301,12 +301,20 @@ def test_param(write_read, t_steps):
         assert not len(parameters_ref["default"]["initial_condition"])
 
 
-@pytest.mark.parametrize("write_read", [write_read_tough, write_read_json])
-def test_indom(write_read):
+@pytest.mark.parametrize(
+    "write_read, num_pvars",
+    [
+        (write_read_tough, 4),
+        (write_read_json, 4),
+        (write_read_tough, 6),
+        (write_read_json, 6),
+    ],
+)
+def test_indom(write_read, num_pvars):
     parameters_ref = {
         "rocks": {
             helpers.random_string(5): {
-                "initial_condition": numpy.random.rand(numpy.random.randint(4) + 1),
+                "initial_condition": numpy.random.rand(num_pvars),
             }
             for _ in numpy.random.rand(10) + 1
         },

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -251,15 +251,17 @@ def test_solvr(write_read):
 
 
 @pytest.mark.parametrize(
-    "write_read, t_steps",
+    "write_read, t_steps, num_pvars",
     [
-        (write_read_tough, numpy.random.rand()),
-        (write_read_tough, numpy.random.rand(numpy.random.randint(100) + 1)),
-        (write_read_json, numpy.random.rand()),
-        (write_read_json, numpy.random.rand(numpy.random.randint(100) + 1)),
+        (write_read_tough, numpy.random.rand(), 4),
+        (write_read_tough, numpy.random.rand(numpy.random.randint(100) + 1), 4),
+        (write_read_tough, numpy.random.rand(numpy.random.randint(100) + 1), 6),
+        (write_read_json, numpy.random.rand(), 4),
+        (write_read_json, numpy.random.rand(numpy.random.randint(100) + 1), 4),
+        (write_read_json, numpy.random.rand(numpy.random.randint(100) + 1), 6),
     ],
 )
-def test_param(write_read, t_steps):
+def test_param(write_read, t_steps, num_pvars):
     parameters_ref = {
         "options": {
             "n_iteration": numpy.random.randint(10),
@@ -285,7 +287,7 @@ def test_param(write_read, t_steps):
         "extra_options": {
             k + 1: v for k, v in enumerate(numpy.random.randint(10, size=24))
         },
-        "default": {"initial_condition": numpy.random.rand(numpy.random.randint(5))},
+        "default": {"initial_condition": numpy.random.rand(num_pvars)},
     }
     parameters = write_read(parameters_ref)
 

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -617,15 +617,17 @@ def test_conne(write_read, label_length):
 
 
 @pytest.mark.parametrize(
-    "write_read, label_length",
+    "write_read, label_length, num_pvars",
     [
-        (write_read_tough, 5),
-        (write_read_json, 5),
-        (write_read_tough, 6),
-        (write_read_json, 6),
+        (write_read_tough, 5, 4),
+        (write_read_json, 5, 4),
+        (write_read_tough, 5, 6),
+        (write_read_json, 5, 6),
+        (write_read_tough, 6, 4),
+        (write_read_json, 6, 4),
     ],
 )
-def test_incon(write_read, label_length):
+def test_incon(write_read, label_length, num_pvars):
     labels = [
         helpers.random_label(label_length) for _ in range(numpy.random.randint(10) + 1)
     ]
@@ -642,7 +644,7 @@ def test_incon(write_read, label_length):
                     if key == "porosity"
                     else numpy.random.rand(numpy.random.randint(5) + 1)
                     if key == "userx"
-                    else numpy.random.rand(numpy.random.randint(4) + 1)
+                    else numpy.random.rand(num_pvars)
                 )
                 for key in keys
             }

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -515,11 +515,9 @@ def test_outpu(write_read, fmt):
             "format": fmt,
             "variables": {
                 helpers.random_string(20): None,
-                helpers.random_string(20): [numpy.random.randint(10)],
-                helpers.random_string(20): [
-                    numpy.random.randint(10),
-                    numpy.random.randint(10),
-                ],
+                helpers.random_string(20): numpy.random.randint(10, size=1),
+                helpers.random_string(20): numpy.random.randint(10, size=2),
+                helpers.random_string(20): numpy.random.randint(10, size=(numpy.random.randint(1, 10), 2)),
             },
         },
     }

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -196,19 +196,33 @@ def test_multi(write_read, isothermal):
     assert parameters_ref["isothermal"] == parameters["isothermal"]
 
 
-@pytest.mark.parametrize("write_read", [write_read_tough, write_read_json])
-def test_selec(write_read):
+@pytest.mark.parametrize(
+    "write_read, num_floats",
+    [
+        (write_read_tough, None),
+        (write_read_tough, 8),
+        (write_read_json, None),
+        (write_read_json, 8),
+    ],
+)
+def test_selec(write_read, num_floats):
     parameters_ref = {
         "selections": {
             "integers": {
                 k + 1: v for k, v in enumerate(numpy.random.randint(100, size=16))
             },
-            "floats": numpy.random.rand(numpy.random.randint(100)),
+            "floats": (
+                numpy.random.rand(num_floats)
+                if num_floats is not None and num_floats <= 8
+                else numpy.random.rand(numpy.random.randint(100) + 1, numpy.random.randint(8) + 1)
+            ),
         },
     }
     parameters_ref["selections"]["integers"][1] = (
-        len(parameters_ref["selections"]["floats"]) - 1
-    ) // 8 + 1
+        len(parameters_ref["selections"]["floats"])
+        if numpy.ndim(parameters_ref["selections"]["floats"]) == 2
+        else 1
+    )
     parameters = write_read(parameters_ref)
 
     helpers.allclose_dict(

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -293,7 +293,9 @@ def test_selec(write_read, num_floats):
             "floats": (
                 numpy.random.rand(num_floats)
                 if num_floats is not None and num_floats <= 8
-                else numpy.random.rand(numpy.random.randint(100) + 1, numpy.random.randint(8) + 1)
+                else numpy.random.rand(
+                    numpy.random.randint(100) + 1, numpy.random.randint(8) + 1
+                )
             ),
         },
     }
@@ -517,7 +519,9 @@ def test_outpu(write_read, fmt):
                 helpers.random_string(20): None,
                 helpers.random_string(20): numpy.random.randint(10, size=1),
                 helpers.random_string(20): numpy.random.randint(10, size=2),
-                helpers.random_string(20): numpy.random.randint(10, size=(numpy.random.randint(1, 10), 2)),
+                helpers.random_string(20): numpy.random.randint(
+                    10, size=(numpy.random.randint(1, 10), 2)
+                ),
             },
         },
     }
@@ -656,9 +660,7 @@ def test_conne(write_read, label_length):
 )
 def test_incon(write_read, label_length, num_pvars, num_items):
     num_items = num_items if num_items else numpy.random.randint(10) + 1
-    labels = [
-        helpers.random_label(label_length) for _ in range(num_items)
-    ]
+    labels = [helpers.random_label(label_length) for _ in range(num_items)]
     keys = [
         "porosity",
         "userx",

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -304,21 +304,24 @@ def test_param(write_read, t_steps, num_pvars):
 
 
 @pytest.mark.parametrize(
-    "write_read, num_pvars",
+    "write_read, num_pvars, num_items",
     [
-        (write_read_tough, 4),
-        (write_read_json, 4),
-        (write_read_tough, 6),
-        (write_read_json, 6),
+        (write_read_tough, 4, None),
+        (write_read_tough, 6, None),
+        (write_read_tough, 4, 1),
+        (write_read_tough, 6, 1),
+        (write_read_json, 4, None),
+        (write_read_json, 6, None),
     ],
 )
-def test_indom(write_read, num_pvars):
+def test_indom(write_read, num_pvars, num_items):
+    num_items = num_items if num_items else numpy.random.randint(10) + 1
     parameters_ref = {
         "rocks": {
             helpers.random_string(5): {
                 "initial_condition": numpy.random.rand(num_pvars),
             }
-            for _ in numpy.random.rand(10) + 1
+            for _ in range(num_items)
         },
     }
     parameters = write_read(parameters_ref)
@@ -627,19 +630,22 @@ def test_conne(write_read, label_length):
 
 
 @pytest.mark.parametrize(
-    "write_read, label_length, num_pvars",
+    "write_read, label_length, num_pvars, num_items",
     [
-        (write_read_tough, 5, 4),
-        (write_read_json, 5, 4),
-        (write_read_tough, 5, 6),
-        (write_read_json, 5, 6),
-        (write_read_tough, 6, 4),
-        (write_read_json, 6, 4),
+        (write_read_tough, 5, 4, None),
+        (write_read_tough, 5, 6, None),
+        (write_read_tough, 6, 4, None),
+        (write_read_tough, 5, 4, 1),
+        (write_read_tough, 5, 6, 1),
+        (write_read_json, 5, 4, None),
+        (write_read_json, 5, 6, None),
+        (write_read_json, 6, 4, None),
     ],
 )
-def test_incon(write_read, label_length, num_pvars):
+def test_incon(write_read, label_length, num_pvars, num_items):
+    num_items = num_items if num_items else numpy.random.randint(10) + 1
     labels = [
-        helpers.random_label(label_length) for _ in range(numpy.random.randint(10) + 1)
+        helpers.random_label(label_length) for _ in range(num_items)
     ]
     keys = [
         "porosity",

--- a/test/test_mesh_methods.py
+++ b/test/test_mesh_methods.py
@@ -191,7 +191,7 @@ def test_near():
     assert mesh.near((1.5, 1.5, 1.5)) == 13
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason="Order of keys in dictionary")
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="Order of keys in dictionary")
 @pytest.mark.parametrize("num_pvars", [4, 6])
 def test_write_tough(num_pvars):
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_mesh_methods.py
+++ b/test/test_mesh_methods.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from copy import deepcopy
 
 import numpy
@@ -190,6 +191,7 @@ def test_near():
     assert mesh.near((1.5, 1.5, 1.5)) == 13
 
 
+@pytest.mark.skipif(sys.version_info < (3,), reason="Order of keys in dictionary")
 @pytest.mark.parametrize("num_pvars", [4, 6])
 def test_write_tough(num_pvars):
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_mesh_methods.py
+++ b/test/test_mesh_methods.py
@@ -188,3 +188,34 @@ def test_near():
     mesh = toughio.meshmaker.structured_grid(dx, dy, dz, origin=numpy.zeros(3))
 
     assert mesh.near((1.5, 1.5, 1.5)) == 13
+
+
+@pytest.mark.parametrize("num_pvars", [4, 6])
+def test_write_tough(num_pvars):
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    filename = os.path.join(this_dir, "support_files", "all_cell_types.f3grid")
+    mesh_ref = toughio.read_mesh(filename)
+
+    tempdir = helpers.tempdir()
+    mesh_filename = os.path.join(tempdir, "MESH")
+    incon_filename = os.path.join(tempdir, "INCON")
+
+    pvars = numpy.random.rand(mesh_ref.n_cells, num_pvars)
+    mesh_ref.add_cell_data("initial_condition", pvars)
+
+    bcond = (mesh_ref.centers[:, 2] < 0.5).astype(int)
+    mesh_ref.add_cell_data("boundary_condition", bcond)
+
+    mesh_ref.write_tough(mesh_filename, incon=True)
+    mesh = toughio.read_input(mesh_filename, file_format="tough")
+    incon = toughio.read_input(incon_filename, file_format="tough")
+
+    volumes = [v["volume"] for v in mesh["elements"].values()]
+    volumes = [v if v < 1.0e20 else v * 1.0e-50 for v in volumes]
+    assert numpy.allclose(mesh_ref.volumes, volumes, atol=1.0e-6)
+
+    centers = [v["center"] for v in mesh["elements"].values()]
+    assert numpy.allclose(mesh_ref.centers, centers, atol=1.0e-3)
+
+    pvars = numpy.row_stack([v["values"] for v in incon["initial_conditions"].values()])
+    assert numpy.allclose(mesh_ref.cell_data["initial_condition"], pvars)

--- a/toughio/_io/input/_helpers.py
+++ b/toughio/_io/input/_helpers.py
@@ -80,8 +80,12 @@ def write(filename, parameters, file_format=None, **kwargs):
 
     Other Parameters
     ----------------
-    mesh : bool, optional, default False
-        Only if ``file_format = "tough"``. If `True`, only write blocks ELEME, COORD, CONNE and INCON.
+    block : str {'all', 'gener', 'mesh', 'incon'}, optional, default 'all'
+        Only if ``file_format = "tough"``. Blocks to be written:
+         - 'all': write all blocks,
+         - 'gener': only write block GENER,
+         - 'mesh': only write blocks ELEME, COORD and CONNE,
+         - 'incon': only write block INCON.
 
     """
     if not isinstance(filename, str):

--- a/toughio/_io/input/tough/_common.py
+++ b/toughio/_io/input/tough/_common.py
@@ -135,7 +135,7 @@ default = {
     "klinkenberg_parameter": None,
     "distribution_coefficient_3": None,
     "distribution_coefficient_4": None,
-    "initial_condition": [None for _ in range(4)],
+    "initial_condition": [None for _ in range(6)],
     "relative_permeability": {"id": None, "parameters": []},
     "capillarity": {"id": None, "parameters": []},
     "permeability_model": {"id": 1, "parameters": []},

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -81,7 +81,7 @@ def read_buffer(f, label_length):
         elif line.startswith("START"):
             parameters["start"] = True
         elif line.startswith("PARAM"):
-            param = _read_param(fiter)
+            param = _read_param(fiter, f)
             parameters["options"] = param["options"]
             parameters["extra_options"] = param["extra_options"]
             if "default" in parameters.keys():
@@ -284,7 +284,7 @@ def _read_solvr(f):
     return solvr
 
 
-def _read_param(f):
+def _read_param(f, fh):
     """Read PARAM block data."""
     fmt = block_to_format["PARAM"]
     param = {}
@@ -345,9 +345,17 @@ def _read_param(f):
         }
     )
 
-    # Record 4
+    # Record 4 and record 5 (EOS7R)
     line = next(f)
     data = read_record(line, fmt[5])
+
+    i = fh.tell()
+    try:
+        line = next(f)
+        data += read_record(line, fmt[5])
+    except ValueError:
+        fh.seek(i)
+
     if any(x is not None for x in data):
         data = prune_nones_list(data)
         param["default"] = {"initial_condition": data}

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -363,17 +363,36 @@ def _read_indom(f):
     fmt = block_to_format["INDOM"]
     indom = {"rocks": {}}
 
+    line = next(f)
+    first = True
+    two_lines = True
     while True:
-        line = next(f)
-
         if line.strip():
+            # Record 1
             rock = read_record(line, fmt[5])[0]
+
+            # Record 2
             line = next(f)
             data = read_record(line, fmt[0])
+
+            # Record 3 (EOS7R)
+            if first or two_lines:
+                try:
+                    line = next(f)
+                    data += read_record(line, fmt[0])
+                except ValueError:
+                    two_lines = False
+
             data = prune_nones_list(data)
             indom["rocks"][rock] = {"initial_condition": data}
         else:
             break
+
+        if not first or two_lines:
+            line = next(f)
+        
+        if first:
+            first = False
 
     return indom
 

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -257,11 +257,11 @@ def _read_selec(f):
         for _ in range(selec["selections"]["integers"][1]):
             line = next(f)
             data = read_record(line, fmt[2])
-            selec["selections"]["floats"] += data
+            selec["selections"]["floats"].append(prune_nones_list(data))
 
     selec["selections"]["integers"] = prune_nones_dict(selec["selections"]["integers"])
-    if selec["selections"]["integers"][1]:
-        selec["selections"]["floats"] = prune_nones_list(selec["selections"]["floats"])
+    if selec["selections"]["integers"][1] == 1:
+        selec["selections"]["floats"] = selec["selections"]["floats"][0]
 
     return selec
 

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -562,21 +562,35 @@ def _read_outpu(f):
         line = next(f).strip()
 
     # Variables
+    names = {}
     if line.isdigit():
-        n_var = int(line)
+        num_vars = int(line)
         outpu["output"]["variables"] = {}
 
-        for _ in range(n_var):
+        for _ in range(num_vars):
             line = next(f)
             data = read_record(line, fmt[3])
             name = data[0].lower()
-            outpu["output"]["variables"][name] = prune_nones_list(data[1:])
-            outpu["output"]["variables"][name] = (
-                outpu["output"]["variables"][name]
-                if len(outpu["output"]["variables"][name]) == 2
-                else outpu["output"]["variables"][name][0]
-                if len(outpu["output"]["variables"][name]) == 1
-                else None
+            
+            tmp = prune_nones_list(data[1:])
+            if name not in names.keys():
+                names[name] = 1
+                outpu["output"]["variables"][name] = tmp
+            else:
+                if names[name] == 1:
+                    outpu["output"]["variables"][name] = [outpu["output"]["variables"][name], tmp]
+                else:
+                    outpu["output"]["variables"][name].append(tmp)
+
+                names[name] += 1
+
+        for k, v in outpu["output"]["variables"].items():
+            outpu["output"]["variables"][k] = (
+                None
+                if len(v) == 0
+                else v[0]
+                if len(v) == 1
+                else v
             )
 
     return outpu

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -388,11 +388,15 @@ def _read_indom(f, fh):
             # Record 3 (EOS7R)
             if two_lines:
                 i = fh.tell()
-                try:
-                    line = next(f)
-                    data += read_record(line, fmt[0])
-                except ValueError:
-                    two_lines = False
+                line = next(f)
+
+                if line.strip():
+                    try:
+                        data += read_record(line, fmt[0])
+                    except ValueError:
+                        two_lines = False
+                        fh.seek(i)
+                else:
                     fh.seek(i)
 
             data = prune_nones_list(data)
@@ -695,11 +699,15 @@ def _read_incon(f, label_length, fh):
             # Record 3 (EOS7R)
             if two_lines:
                 i = fh.tell()
-                try:
-                    line = next(f)
-                    data += read_record(line, fmt[0])
-                except ValueError:
-                    two_lines = False
+                line = next(f)
+
+                if line.strip() and not line.startswith("+++"):
+                    try:
+                        data += read_record(line, fmt[0])
+                    except ValueError:
+                        two_lines = False
+                        fh.seek(i)
+                else:
                     fh.seek(i)
 
             incon["initial_conditions"][label]["values"] = prune_nones_list(data)

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -74,8 +74,6 @@ def read_buffer(f, label_length):
                 parameters["rocks"][k].update(v)
         elif line.startswith("MULTI"):
             parameters.update(_read_multi(fiter))
-        elif line.startswith("SELEC"):
-            parameters.update(_read_selec(fiter))
         elif line.startswith("SOLVR"):
             parameters.update(_read_solvr(fiter))
         elif line.startswith("START"):
@@ -88,6 +86,8 @@ def read_buffer(f, label_length):
                 parameters["default"].update(param["default"])
             else:
                 parameters["default"] = param["default"]
+        elif line.startswith("SELEC"):
+            parameters.update(_read_selec(fiter))
         elif line.startswith("INDOM"):
             indom = _read_indom(fiter, f)
             for k, v in indom["rocks"].items():
@@ -243,29 +243,6 @@ def _read_multi(f):
     return multi
 
 
-def _read_selec(f):
-    """Read SELEC block data."""
-    fmt = block_to_format["SELEC"]
-    selec = {"selections": {}}
-
-    line = next(f)
-    data = read_record(line, fmt[1])
-    selec["selections"]["integers"] = {k + 1: v for k, v in enumerate(data)}
-
-    if selec["selections"]["integers"][1]:
-        selec["selections"]["floats"] = []
-        for _ in range(selec["selections"]["integers"][1]):
-            line = next(f)
-            data = read_record(line, fmt[2])
-            selec["selections"]["floats"].append(prune_nones_list(data))
-
-    selec["selections"]["integers"] = prune_nones_dict(selec["selections"]["integers"])
-    if selec["selections"]["integers"][1] == 1:
-        selec["selections"]["floats"] = selec["selections"]["floats"][0]
-
-    return selec
-
-
 def _read_solvr(f):
     """Read SOLVR block data."""
     fmt = block_to_format["SOLVR"]
@@ -367,6 +344,29 @@ def _read_param(f, fh):
     param["extra_options"] = prune_nones_dict(param["extra_options"])
 
     return param
+
+
+def _read_selec(f):
+    """Read SELEC block data."""
+    fmt = block_to_format["SELEC"]
+    selec = {"selections": {}}
+
+    line = next(f)
+    data = read_record(line, fmt[1])
+    selec["selections"]["integers"] = {k + 1: v for k, v in enumerate(data)}
+
+    if selec["selections"]["integers"][1]:
+        selec["selections"]["floats"] = []
+        for _ in range(selec["selections"]["integers"][1]):
+            line = next(f)
+            data = read_record(line, fmt[2])
+            selec["selections"]["floats"].append(prune_nones_list(data))
+
+    selec["selections"]["integers"] = prune_nones_dict(selec["selections"]["integers"])
+    if selec["selections"]["integers"][1] == 1:
+        selec["selections"]["floats"] = selec["selections"]["floats"][0]
+
+    return selec
 
 
 def _read_indom(f, fh):

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -105,7 +105,7 @@ def read_buffer(f, label_length):
         elif line.startswith("GENER"):
             parameters.update(_read_gener(fiter, label_length))
         elif line.startswith("DIFFU"):
-            parameters.update(_read_diffu(fiter))
+            parameters.update(_read_diffu(fiter, f))
         elif line.startswith("OUTPU"):
             parameters.update(_read_outpu(fiter))
         elif line.startswith("ELEME"):
@@ -524,15 +524,24 @@ def _read_gener(f, label_length):
     }
 
 
-def _read_diffu(f):
+def _read_diffu(f, fh):
     """Read DIFFU block data."""
     fmt = block_to_format["DIFFU"]
     diffu = {"diffusion": []}
 
-    for _ in range(2):
+    while True:
+        i = fh.tell()
         line = next(f)
-        data = read_record(line, fmt)
-        diffu["diffusion"].append(prune_nones_list(data))
+
+        if line.split():
+            try:
+                data = read_record(line, fmt)
+                diffu["diffusion"].append(prune_nones_list(data))
+            except ValueError:
+                fh.seek(i)
+                break
+        else:
+            break
 
     return diffu
 

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -403,7 +403,7 @@ def _read_indom(f, fh):
             indom["rocks"][rock] = {"initial_condition": data}
         else:
             break
-        
+
         line = next(f)
 
     return indom
@@ -571,14 +571,17 @@ def _read_outpu(f):
             line = next(f)
             data = read_record(line, fmt[3])
             name = data[0].lower()
-            
+
             tmp = prune_nones_list(data[1:])
             if name not in names.keys():
                 names[name] = 1
                 outpu["output"]["variables"][name] = tmp
             else:
                 if names[name] == 1:
-                    outpu["output"]["variables"][name] = [outpu["output"]["variables"][name], tmp]
+                    outpu["output"]["variables"][name] = [
+                        outpu["output"]["variables"][name],
+                        tmp,
+                    ]
                 else:
                     outpu["output"]["variables"][name].append(tmp)
 
@@ -586,11 +589,7 @@ def _read_outpu(f):
 
         for k, v in outpu["output"]["variables"].items():
             outpu["output"]["variables"][k] = (
-                None
-                if len(v) == 0
-                else v[0]
-                if len(v) == 1
-                else v
+                None if len(v) == 0 else v[0] if len(v) == 1 else v
             )
 
     return outpu
@@ -693,7 +692,7 @@ def _read_incon(f, label_length, fh):
     line = next(f)
     if not label_length:
         label_length = get_label_length(line[:9])
-    
+
     two_lines = True
     while True:
         if line.strip() and not line.startswith("+++"):

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -500,17 +500,27 @@ def _write_indom(parameters):
 
     # Formats
     fmt = block_to_format["INDOM"]
-    fmt = str2format(fmt[5]) + str2format(fmt[0])
-    fmt[0] = "{}\n".format(fmt[0])
+    fmt1 = str2format(fmt[5])
+    fmt2 = str2format(fmt[0])
 
     out = []
     for k in order:
         if "initial_condition" in parameters["rocks"][k]:
             data = parameters["rocks"][k]["initial_condition"]
             if any(x is not None for x in data):
+                # Record 1
                 values = [k]
-                values += list(data)
-                out += write_record(values, fmt)
+                out += write_record(values, fmt1)
+
+                # Record 2
+                n = min(4, len(data))
+                values = list(data[:n])
+                out += write_record(values, fmt2)
+
+                # Record 3
+                if len(data) > 4:
+                    values = list(data[4:])
+                    out += write_record(values, fmt2)
 
     return out
 

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -724,19 +724,13 @@ def _write_gener(parameters):
 @block("DIFFU")
 def _write_diffu(parameters):
     """Write DIFFU block data."""
-    if numpy.shape(parameters["diffusion"]) != (2, parameters["n_phase"]):
-        raise ValueError()
-    mass1, mass2 = parameters["diffusion"]
-
     # Format
     fmt = block_to_format["DIFFU"]
     fmt = str2format(fmt)
 
-    # Record 1
-    out = write_record(mass1, fmt, multi=True)
-
-    # Record 2
-    out += write_record(mass2, fmt, multi=True)
+    out = []
+    for mass in parameters["diffusion"]:
+        out += write_record(mass, fmt, multi=True)
 
     return out
 

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -481,8 +481,14 @@ def _write_param(parameters):
     out += write_record(values, fmt4)
 
     # Record 4
-    values = parameters["default"]["initial_condition"]
+    n = min(4, len(parameters["default"]["initial_condition"]))
+    values = parameters["default"]["initial_condition"][:n]
     out += write_record(values, fmt5)
+
+    # Record 5 (EOS7R)
+    if len(parameters["default"]["initial_condition"]) > 4:
+        values = parameters["default"]["initial_condition"][n:]
+        out += write_record(values, fmt5)
 
     return out
 

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -780,19 +780,27 @@ def _write_outpu(parameters):
 
     # Variables
     if data["variables"]:
-        out += write_record([str(len(data["variables"]))], fmt2)
-
+        buffer = []
+        num_vars = 0
         for k, v in data["variables"].items():
             values = [k.upper()]
 
-            if v is not None:
-                v = list(v) if isinstance(v, (list, tuple, numpy.ndarray)) else [v]
-                if not (0 < len(v) < 3):
-                    raise ValueError()
+            if numpy.ndim(v) == 0:
+                buffer += write_record(values, fmt3)
+                num_vars += 1
+            else:
+                if numpy.ndim(v[0]) == 0:
+                    values += list(v)
+                    buffer += write_record(values, fmt3)
+                    num_vars += 1
                 else:
-                    values += v
+                    for vv in v:
+                        values_in = values + list(vv)
+                        buffer += write_record(values_in, fmt3)
+                    num_vars += len(v)
 
-            out += write_record(values, fmt3)
+        out += write_record([str(num_vars)], fmt2)
+        out += buffer
 
     return out
 

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -903,7 +903,12 @@ def _write_incon(parameters):
         out += write_record(values, fmt1)
 
         # Record 2
-        out += write_record(data["values"], fmt2)
+        n = min(4, len(data["values"]))
+        out += write_record(data["values"][:n], fmt2)
+
+        # Record 3 (EOS7R)
+        if len(data["values"]) > 4:
+            out += write_record(data["values"][4:], fmt2)
 
     return out
 

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -359,6 +359,25 @@ def _write_selec(parameters):
     if len(parameters["selections"]["floats"]):
         data["floats"] = parameters["selections"]["floats"]
 
+    # Check floats and overwrite IE(1)
+    if data["floats"] is not None and len(data["floats"]):
+        if isinstance(data["floats"][0], (list, tuple, numpy.ndarray)):
+            for x in data["floats"]:
+                if len(x) > 8:
+                    raise ValueError()
+
+            data["integers"][1] = len(data["floats"])
+            ndim = 2
+
+        else:
+            if len(data["floats"]) > 8:
+                raise ValueError()
+
+            data["integers"][1] = 1
+            ndim = 1
+    else:
+        ndim = None
+
     # Formats
     fmt = block_to_format["SELEC"]
     fmt1 = str2format(fmt[1])
@@ -369,8 +388,11 @@ def _write_selec(parameters):
     out = write_record(values, fmt1)
 
     # Record 2
-    if data["floats"] is not None and len(data["floats"]):
-        out += write_record(data["floats"], fmt2, multi=True)
+    if ndim == 1:
+        out += write_record(data["floats"], fmt2)
+    elif ndim == 2:
+        for x in data["floats"]:
+            out += write_record(x, fmt2)
 
     return out
 

--- a/toughio/_mesh/tough/_helpers.py
+++ b/toughio/_mesh/tough/_helpers.py
@@ -114,9 +114,10 @@ def _write_incon(labels, values, porosity=None, userx=None):
             record = fmt1.format(*values)
 
             # Record 2
+            n = min(4, len(value))
             values = []
             ignore_types = []
-            for i, v in enumerate(value):
+            for i, v in enumerate(value[:n]):
                 if v > -1.0e9:
                     values.append(v)
                 else:
@@ -126,6 +127,21 @@ def _write_incon(labels, values, porosity=None, userx=None):
             fmt2 = str2format(fmt[0], ignore_types=ignore_types)
             fmt2 = "{}\n".format("".join(fmt2[: len(values)]))
             record += fmt2.format(*values)
+
+            # Record 3 (EOS7R)
+            if len(value) > 4:
+                values = []
+                ignore_types = []
+                for i, v in enumerate(value[n:]):
+                    if v > -1.0e9:
+                        values.append(v)
+                    else:
+                        values.append("")
+                        ignore_types.append(i)
+
+                fmt2 = str2format(fmt[0], ignore_types=ignore_types)
+                fmt2 = "{}\n".format("".join(fmt2[: len(values)]))
+                record += fmt2.format(*values)
 
             yield record
         else:


### PR DESCRIPTION
- Fixed: error when more than 4 primary variables in INCON, INDOM and PARAM blocks (e.g., EOS7R)
- Fixed: block DIFFU with more than 2 components
- Fixed: block OUTPU with repeated variable names but different phase and/or component
- Changed: block SELEC float items must be defined as a list of lists (one list per record) if more than 8 values

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
