### PR TITLE
Add mesh filter

### DIFF
--- a/test/test_mesh_methods.py
+++ b/test/test_mesh_methods.py
@@ -152,12 +152,20 @@ def test_add_cell_data():
     assert numpy.allclose(data, mesh.cell_data["a"])
 
 
-def test_set_material():
+@pytest.mark.parametrize("bool_cells", [False, True])
+def test_set_material(bool_cells):
     dx = numpy.ones(10)
     dy = numpy.ones(10)
     dz = numpy.ones(10)
     mesh = toughio.meshmaker.structured_grid(dx, dy, dz, origin=numpy.zeros(3))
-    mesh.set_material("test", xlim=(4.0, 6.0), ylim=(4.0, 6.0), zlim=(4.0, 6.0))
+    
+    idx = mesh.filter.box(4.0, 4.0, 4.0, 2.0, 2.0, 2.0)
+    if bool_cells:
+        cells = numpy.zeros(mesh.n_cells, dtype=bool)
+        cells[idx] = True
+    else:
+        cells = idx
+    mesh.set_material("test", cells)
 
     assert (mesh.materials == "test").sum() == 8
 

--- a/test/test_mesh_methods.py
+++ b/test/test_mesh_methods.py
@@ -158,7 +158,7 @@ def test_set_material(bool_cells):
     dy = numpy.ones(10)
     dz = numpy.ones(10)
     mesh = toughio.meshmaker.structured_grid(dx, dy, dz, origin=numpy.zeros(3))
-    
+
     idx = mesh.filter.box(4.0, 4.0, 4.0, 2.0, 2.0, 2.0)
     if bool_cells:
         cells = numpy.zeros(mesh.n_cells, dtype=bool)

--- a/toughio/_mesh/_filter/__init__.py
+++ b/toughio/_mesh/_filter/__init__.py
@@ -1,0 +1,6 @@
+from . import box
+from ._helpers import MeshFilter
+
+__all__ = [
+    "MeshFilter",
+]

--- a/toughio/_mesh/_filter/_helpers.py
+++ b/toughio/_mesh/_filter/_helpers.py
@@ -1,7 +1,3 @@
-from functools import partial
-
-import numpy
-
 __all__ = [
     "MeshFilter",
 ]

--- a/toughio/_mesh/_filter/_helpers.py
+++ b/toughio/_mesh/_filter/_helpers.py
@@ -1,0 +1,81 @@
+from functools import partial
+
+import numpy
+
+__all__ = [
+    "MeshFilter",
+]
+
+
+_filter_map = {}
+
+
+def register(filter_name, filter_):
+    """Register a new filter."""
+    _filter_map[filter_name] = filter_
+
+
+class MeshFilter(object):
+    def __init__(self, mesh):
+        """
+        Mesh filter.
+
+        Parameters
+        ----------
+        mesh : toughio.Mesh
+            Mesh to filter.
+        
+        """
+        self._mesh = mesh
+
+    def __call__(self, filter_="box", **kwargs):
+        """
+        Filter mesh.
+
+        Parameters
+        ----------
+        filter_ : str, optional, default 'box'
+            Filter method.
+        
+        Returns
+        -------
+        array_like
+            Indices of cells filtered.
+        
+        """
+        return _filter_map[filter_](self._mesh, **kwargs)
+
+    def box(self, x0=None, y0=None, z0=None, dx=None, dy=None, dz=None):
+        """
+        Box filter.
+
+        Parameters
+        ----------
+        x0 : scalar or None, optional, default None
+            Minimum value in X direction.
+        y0 : scalar or None, optional, default None
+            Minimum value in Y direction.
+        z0 : scalar or None, optional, default None
+            Minimum value in Z direction.
+        dx : scalar or None, optional, default None
+            Box length in X direction.
+        dy : scalar or None, optional, default None
+            Box length in Y direction.
+        dz : scalar or None, optional, default None
+            Box length in Z direction.
+
+        Returns
+        -------
+        array_like
+            Indices of cells within the domain defined by the box.
+        
+        """
+        return self(
+            filter_="box",
+            x0=x0,
+            y0=y0,
+            z0=z0,
+            dx=dx,
+            dy=dy,
+            dz=dz,
+        )

--- a/toughio/_mesh/_filter/_helpers.py
+++ b/toughio/_mesh/_filter/_helpers.py
@@ -24,7 +24,7 @@ class MeshFilter(object):
         ----------
         mesh : toughio.Mesh
             Mesh to filter.
-        
+
         """
         self._mesh = mesh
 
@@ -36,12 +36,12 @@ class MeshFilter(object):
         ----------
         filter_ : str, optional, default 'box'
             Filter method.
-        
+
         Returns
         -------
         array_like
             Indices of cells filtered.
-        
+
         """
         return _filter_map[filter_](self._mesh, **kwargs)
 
@@ -68,14 +68,6 @@ class MeshFilter(object):
         -------
         array_like
             Indices of cells within the domain defined by the box.
-        
+
         """
-        return self(
-            filter_="box",
-            x0=x0,
-            y0=y0,
-            z0=z0,
-            dx=dx,
-            dy=dy,
-            dz=dz,
-        )
+        return self(filter_="box", x0=x0, y0=y0, z0=z0, dx=dx, dy=dy, dz=dz,)

--- a/toughio/_mesh/_filter/box/__init__.py
+++ b/toughio/_mesh/_filter/box/__init__.py
@@ -1,0 +1,5 @@
+from ._box import filter_
+
+__all__ = [
+    "filter_",
+]

--- a/toughio/_mesh/_filter/box/_box.py
+++ b/toughio/_mesh/_filter/box/_box.py
@@ -1,0 +1,29 @@
+import numpy
+
+from .._helpers import register
+
+__all__ = [
+    "filter_",
+]
+
+
+def filter_(mesh, x0=None, y0=None, z0=None, dx=None, dy=None, dz=None):
+    """Box filter."""
+    xmin = x0 if x0 else -numpy.inf
+    ymin = y0 if y0 else -numpy.inf
+    zmin = z0 if z0 else -numpy.inf
+
+    xmax = xmin + dx if dx else numpy.inf
+    ymax = ymin + dy if dy else numpy.inf
+    zmax = zmin + dz if dz else numpy.inf
+
+    x, y, z = mesh.centers.T
+    mask_x = numpy.logical_and(x >= xmin, x <= xmax)
+    mask_y = numpy.logical_and(y >= ymin, y <= ymax)
+    mask_z = numpy.logical_and(z >= zmin, z <= zmax)
+    mask = numpy.logical_and(numpy.logical_and(mask_x, mask_y), mask_z)
+
+    return numpy.arange(mesh.n_cells)[mask]
+
+
+register("box", filter_)

--- a/toughio/_mesh/_mesh.py
+++ b/toughio/_mesh/_mesh.py
@@ -5,6 +5,7 @@ import meshio
 import numpy
 
 from ._common import get_meshio_version, get_new_meshio_cells, get_old_meshio_cells
+from ._filter import MeshFilter
 from ._properties import (
     _connections,
     _face_areas,
@@ -529,71 +530,40 @@ class Mesh(object):
             raise ValueError()
         self.cell_data[label] = numpy.asarray(data)
 
-    def set_material(self, material, xlim=None, ylim=None, zlim=None):
+    def set_material(self, material, cells):
         """
-        Set material to cells in box.
-
-        Set material for cells within box selection defined by `xlim`, `ylim` and `zlim`.
+        Set material to cells.
 
         Parameters
         ----------
         material : str
             Material name.
-        xlim : array_like or None, optional, default None
-            Minimum and maximum values in X direction.
-        ylim : array_like or None, optional, default None
-            Minimum and maximum values in Y direction.
-        zlim : array_like or None, optional, default None
-            Minimum and maximum values in Z direction.
-
-        Raises
-        ------
-        AssertionError
-            If any input argument is not valid.
+        cells : array_like
+            Indices of cells or array of booleans.
 
         """
+        ints = (int, numpy.int8, numpy.int16, numpy.int32, numpy.int64)
+        cond_int = all(isinstance(c, ints) for c in cells)
+        cond_bool = all(isinstance(c, (bool, numpy.bool_)) for c in cells)
 
-        def isinbounds(x, bounds):
-            return (
-                numpy.logical_and(x >= min(bounds), x <= max(bounds))
-                if bounds is not None
-                else numpy.ones(len(x), dtype=bool)
-            )
-
-        if not isinstance(material, str):
+        if cond_int:
+            if numpy.min(cells) < 0 or numpy.max(cells) >= self.n_cells:
+                raise ValueError()
+        elif cond_bool:
+            if len(cells) != self.n_cells:
+                raise ValueError()
+            cells = numpy.arange(self.n_cells)[cells]
+        else:
             raise TypeError()
-        if not (xlim is not None or ylim is not None or zlim is not None):
-            raise TypeError()
-        if not (
-            xlim is None
-            or (isinstance(xlim, (list, tuple, numpy.ndarray)) and len(xlim) == 2)
-        ):
-            raise ValueError()
-        if not (
-            ylim is None
-            or (isinstance(ylim, (list, tuple, numpy.ndarray)) and len(ylim) == 2)
-        ):
-            raise ValueError()
-        if not (
-            zlim is None
-            or (isinstance(zlim, (list, tuple, numpy.ndarray)) and len(zlim) == 2)
-        ):
-            raise ValueError()
 
-        x, y, z = self.centers.T
-        mask_x = isinbounds(x, xlim)
-        mask_y = isinbounds(y, ylim)
-        mask_z = isinbounds(z, zlim)
-        mask = numpy.logical_and(numpy.logical_and(mask_x, mask_y), mask_z)
-
-        if mask.any():
+        if len(cells):
             data = self.cell_data["material"]
             imat = (
                 self.field_data[material][0]
                 if material in self.field_data.keys()
                 else data.max() + 1
             )
-            data[mask] = imat
+            data[cells] = imat
             self.add_cell_data("material", data)
             self.field_data[material] = numpy.array([imat, 3])
 
@@ -827,6 +797,24 @@ class Mesh(object):
 
         """
         return numpy.array([numpy.min(out) for out in _qualities(self)])
+
+    @property
+    def filter(self):
+        """
+        Filter mesh.
+
+        Parameters
+        ----------
+        filter_ : str, optional, default 'box'
+            Filter method.
+        
+        Returns
+        -------
+        array_like
+            Indices of cells filtered.
+        
+        """
+        return MeshFilter(self)
 
 
 def from_meshio(mesh, material="dfalt"):

--- a/toughio/_mesh/_mesh.py
+++ b/toughio/_mesh/_mesh.py
@@ -807,12 +807,12 @@ class Mesh(object):
         ----------
         filter_ : str, optional, default 'box'
             Filter method.
-        
+
         Returns
         -------
         array_like
             Indices of cells filtered.
-        
+
         """
         return MeshFilter(self)
 


### PR DESCRIPTION
- Added: new `toughio.Mesh.filter` method which returns a list of cell indices
- Changed: `toughio.Mesh.set_material` needs a list of cell indices as input. `toughio.Mesh.set_material` was too restrictive and could only be used to set material in a box domain

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
