### PR TITLE
Fix reader for TOUGH2 output files with more than 9999 cells

### DIFF
--- a/examples/co2_leakage_along_a_fault/4_import_and_visualize_simulation_outputs_in_pyvista.py
+++ b/examples/co2_leakage_along_a_fault/4_import_and_visualize_simulation_outputs_in_pyvista.py
@@ -61,7 +61,6 @@ p.show_grid(
     zlabel="Elevation (m)",
     ticks="outside",
     font_family="arial",
-    shadow=True,
 )
 p.view_xz()
 p.show()

--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.5"
+__version__ = "1.4.6"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_io/output/tough/_tough.py
+++ b/toughio/_io/output/tough/_tough.py
@@ -93,7 +93,7 @@ def _read_table(f, file_type, label_length):
                     if first:
                         try:
                             # Set line parser and try parsing first line
-                            reader = lambda line: [str2float(x) for x in line.split()]
+                            reader = lambda line: [_str2float(x) for x in line.split()]
                             _ = reader(line)
 
                         except ValueError:
@@ -130,3 +130,12 @@ def _read_table(f, file_type, label_length):
                     break
 
     return headers, times, variables
+
+
+def _str2float(x):
+    """Return numpy.nan if x cannot be converted."""
+    try:
+        return str2float(x)
+
+    except ValueError:
+        return numpy.nan


### PR DESCRIPTION
- Fixed:  TOUGH2 returns `****` for cell indices greater than 9999 (issue #84).

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
