### PR TITLE
Fix label length in GENER block

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -835,7 +835,7 @@ def _write_gener(parameters):
             generator_data.append((k, data))
 
     # Format
-    label_length = len(max(parameters["generators"], key=len))
+    label_length = max(len(max(parameters["generators"], key=len)), 5)
     fmt = block_to_format["GENER"]
     fmt1 = str2format(fmt[label_length])
     fmt2 = str2format(fmt[0])


### PR DESCRIPTION
- Fixed: `KeyError` when label's length is less than 5.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
