### PR TITLE
Fix from_meshmaker

### DIFF
--- a/toughio/meshmaker/_helpers.py
+++ b/toughio/meshmaker/_helpers.py
@@ -232,10 +232,12 @@ def append(sizes, n_increment, size, type="uniform", radius_ref=None):
         sizes += [size] * n_increment
 
     elif type == "logarithmic":
-        if not len(sizes):
-            raise ValueError()
+        if not radius_ref:
+            if not len(sizes):
+                raise ValueError()
 
-        radius_ref = radius_ref if radius_ref else sizes[-1]
+            radius_ref = sizes[-1]
+
         f = get_factor(n_increment, size, radius_ref)
 
         sizes.append(f * radius_ref)


### PR DESCRIPTION
- Fixed: function `from_meshmaker` when `"type"` is `"logarithmic"`.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
