### PR TITLE
Fix bug in coordinates format in function write_tough

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_mesh/tough/_helpers.py
+++ b/toughio/_mesh/tough/_helpers.py
@@ -1,4 +1,5 @@
 from ..._common import block_to_format, str2format
+from ..._io.input.tough._helpers import write_record
 
 
 def block(keyword):
@@ -24,7 +25,7 @@ def _write_eleme(labels, materials, volumes, nodes, material_name=None):
     """Return a generator that iterates over the records of block ELEME."""
     label_length = len(labels[0])
     fmt = block_to_format["ELEME"][label_length]
-    fmt = "{}\n".format("".join(str2format(fmt, ignore_types=[1, 2, 5, 6])))
+    fmt = str2format(fmt)
 
     iterables = zip(labels, materials, volumes, nodes)
     for label, material, volume, node in iterables:
@@ -34,19 +35,22 @@ def _write_eleme(labels, materials, volumes, nodes, material_name=None):
             else material
         )
         mat = mat if isinstance(mat, str) else "{:>5}".format(str(mat))
-        record = fmt.format(
-            label,  # ID
-            "",  # NSEQ
-            "",  # NADD
-            mat,  # MAT
-            volume,  # VOLX
-            "",  # AHTX
-            "",  # PMX
-            node[0],  # X
-            node[1],  # Y
-            node[2],  # Z
+        record = write_record(
+            [
+                label,  # ID
+                None,  # NSEQ
+                None,  # NADD
+                mat,  # MAT
+                volume,  # VOLX
+                None,  # AHTX
+                None,  # PMX
+                node[0],  # X
+                node[1],  # Y
+                node[2],  # Z
+            ],
+            fmt=fmt,
         )
-        yield record
+        yield record[0]
 
 
 def _write_coord(nodes):
@@ -62,23 +66,26 @@ def _write_conne(clabels, isot, d1, d2, areas, angles):
     """Return a generator that iterates over the records of block CONNE."""
     label_length = len(clabels[0][0])
     fmt = block_to_format["CONNE"][label_length]
-    fmt = "{}\n".format("".join(str2format(fmt, ignore_types=[1, 2, 3, 9])))
+    fmt = str2format(fmt)
 
     iterables = zip(clabels, isot, d1, d2, areas, angles)
     for label, isot, d1, d2, area, angle in iterables:
-        record = fmt.format(
-            "".join(label),  # ID1-ID2
-            "",  # NSEQ
-            "",  # NAD1
-            "",  # NAD2
-            isot,  # ISOT
-            d1,  # D1
-            d2,  # D2
-            area,  # AREAX
-            angle,  # BETAX
-            "",  # SIGX
+        record = write_record(
+            [
+                "".join(label),  # ID1-ID2
+                None,  # NSEQ
+                None,  # NAD1
+                None,  # NAD2
+                isot,  # ISOT
+                d1,  # D1
+                d2,  # D2
+                area,  # AREAX
+                angle,  # BETAX
+                None,  # SIGX
+            ],
+            fmt=fmt,
         )
-        yield record
+        yield record[0]
 
 
 def _write_incon(


### PR DESCRIPTION
- Fixed: misalignment due to recent format update for element coordinates. This is because function `write_tough` was not using the function `write_record` that checks the length of output string.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
