### PR TITLE
Fix reader for sample file in issue #110

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -627,11 +627,12 @@ def _read_oft(f, oft, label_length):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
+    label_format = "{{:>{}}}".format(label_length if oft != "COFT" else 2 * label_length)
 
     while True:
         if line.strip():
             data = read_record(line, fmt[label_length])
-            history[key].append(data[0])
+            history[key].append(label_format.format(data[0]))
 
         else:
             break
@@ -649,13 +650,14 @@ def _read_gener(f, label_length):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
+    label_format = "{{:>{}}}".format(label_length)
 
     while True:
         if line.strip():
             data = read_record(line, fmt[label_length])
             tmp = {
-                "label": data[0],
-                "name": data[1],
+                "label": label_format.format(data[0]),
+                "name": "{:>5}".format(data[1]) if data[1] else data[1],
                 "nseq": data[2],
                 "nadd": data[3],
                 "nads": data[4],
@@ -760,11 +762,12 @@ def _read_eleme(f, label_length):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
+    label_format = "{{:>{}}}".format(label_length)
 
     while True:
         if line.strip():
             data = read_record(line, fmt[label_length])
-            label = data[0]
+            label = label_format.format(data[0])
             rock = data[3].strip()
             eleme["elements"][label] = {
                 "nseq": data[1],
@@ -813,12 +816,13 @@ def _read_conne(f, label_length):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
+    label_format = "{{:>{}}}".format(2 * label_length)
 
     flag = False
     while True:
         if line.strip() and not line.startswith("+++"):
             data = read_record(line, fmt[label_length])
-            label = data[0]
+            label = label_format.format(data[0])
             conne["connections"][label] = {
                 "nseq": data[1],
                 "nadd": data[2:4],
@@ -852,6 +856,7 @@ def _read_incon(f, label_length, eos=None):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
+    label_format = "{{:>{}}}".format(label_length)
 
     # Guess the number of lines to read for primary variables
     i = f.tell()
@@ -872,7 +877,7 @@ def _read_incon(f, label_length, eos=None):
         if line.strip() and not line.startswith("+++"):
             # Record 1
             data = read_record(line, fmt2[label_length])
-            label = data[0]
+            label = label_format.format(data[0])
             incon["initial_conditions"][label] = {"porosity": data[3]}
 
             if eos == "tmvoc":

--- a/toughio/_io/input/tough/_read.py
+++ b/toughio/_io/input/tough/_read.py
@@ -627,7 +627,9 @@ def _read_oft(f, oft, label_length):
     line = f.next()
     if not label_length:
         label_length = get_label_length(line[:9])
-    label_format = "{{:>{}}}".format(label_length if oft != "COFT" else 2 * label_length)
+    label_format = "{{:>{}}}".format(
+        label_length if oft != "COFT" else 2 * label_length
+    )
 
     while True:
         if line.strip():


### PR DESCRIPTION
- Fixed: number of lines to read for primary variables in block INCON was incorrectly inferred (fix main issue #110).
- Fixed: labels like `"  111"` were stripped off their left white spaces.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
