### PR TITLE
Various fixes for toughio-dash

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_io/input/tough/_common.py
+++ b/toughio/_io/input/tough/_common.py
@@ -42,7 +42,7 @@ _Parameters = {
     "chemical_properties": {},
     "non_condensible_gas": [],
     "isothermal": False,
-    "start": True,
+    "start": False,
     "nover": False,
     "rocks": {},
     "rocks_order": None,

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -148,13 +148,20 @@ def write_buffer(params, block, ignore_blocks=None, eos_=None, simulator="tough"
         parameters["more_options"] = {
             int(k): v for k, v in parameters["more_options"].items()
         }
+
     if "extra_options" in parameters:
         parameters["extra_options"] = {
             int(k): v for k, v in parameters["extra_options"].items()
         }
+
     if "selections" in parameters and "integers" in parameters["selections"]:
         parameters["selections"]["integers"] = {
             int(k): v for k, v in parameters["selections"]["integers"].items()
+        }
+
+    if "react" in parameters and "options" in parameters["react"]:
+        parameters["react"]["options"] = {
+            int(k): v for k, v in parameters["react"]["options"].items()
         }
 
     # Check that EOS is defined (for block MULTI)

--- a/toughio/_io/input/tough/_write.py
+++ b/toughio/_io/input/tough/_write.py
@@ -1075,6 +1075,8 @@ def _write_gener(parameters, simulator="tough"):
             if len(data["conductivity_factors"]) != ktab:
                 raise ValueError()
 
+            ktab = ktab if ktab else None
+
         # Record 1
         values = [
             data["label"] if "label" in data else "",


### PR DESCRIPTION
- Fixed: MOPR when key is string instead of integer.
- Fixed: set KTAB to None if len is zero.
- Fixed: filter out blocks related to TOUGHREACT when `file_format` is not `toughreact-flow`.
- Fixed: default key "start" to False.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
