### PR TITLE
Temporary fix for TOUGHREACT chemical input file

### DIFF
--- a/toughio/__about__.py
+++ b/toughio/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.10.4"
+__version__ = "1.10.5"
 __author__ = "Keurfon Luu"
 __author_email__ = "keurfonluu@lbl.gov"
 __website__ = "https://github.com/keurfonluu/toughio"

--- a/toughio/_io/input/toughreact_chemical/_read.py
+++ b/toughio/_io/input/toughreact_chemical/_read.py
@@ -587,6 +587,17 @@ def _read_imin(f):
                 tmp2["area_ini"] = to_float(data[1])
                 tmp2["area_unit"] = int(data[2])
 
+                # TODO: investigate what is the next record when IMFLG2 < 0
+                # This record is not documented in the user guide (p. 65)
+                if tmp2["area_unit"] < 0:
+                    data = _nextsplitline(f, 4)
+                    tmp2["unknown"] = [
+                        int(data[0]),
+                        to_float(data[1]),
+                        int(data[2]),
+                        to_float(data[3]),
+                    ]
+
             tmp["species"].append(tmp2)
             line = _nextline(f).strip()
 

--- a/toughio/_io/input/toughreact_chemical/_write.py
+++ b/toughio/_io/input/toughreact_chemical/_write.py
@@ -517,7 +517,7 @@ def _write_imin(parameters, verbose):
 
     for i, zone in enumerate(parameters["zones"]["minerals"]):
         # Record 4
-        values = [i + 1] if "rock" not in zone else [-1, f"'{zone['rock'][:5]}'"]
+        values = [i + 1] if "rock" not in zone else [-(i + 1), f"'{zone['rock'][:5]}'"]
         out += write_ffrecord(values)
 
         # Record 6
@@ -539,13 +539,20 @@ def _write_imin(parameters, verbose):
 
                 # Record 6.1
                 if flag == 1:
+                    area_unit = getval(mineral, "area_unit", 0)
                     values = [
                         getval(mineral, "radius", 0.0),
                         getval(mineral, "area_ini", 0.0),
-                        getval(mineral, "area_unit", 0),
+                        area_unit,
                     ]
                     out += write_ffrecord(values, verbose)
                     out[-1] = out[-1].lstrip()
+
+                    # TODO: investigate what is the next record when IMFLG2 < 0
+                    # This record is not documented in the user guide (p. 65)
+                    if area_unit < 0:
+                        values = getval(mineral, "unknown", [])
+                        out += write_ffrecord(values, verbose)
 
         # Record 7
         out += ["*"]


### PR DESCRIPTION
- Fixed: mineral zones of a sample TOUGHREACT chemical input file could not be read due to missing description in user guide. Read the non-described additional line and temporarily set it in key `"unknown"` until fixed.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
