### PR TITLE
Floating centers precision revision

### DIFF
--- a/toughio/_mesh/tough/_tough.py
+++ b/toughio/_mesh/tough/_tough.py
@@ -366,6 +366,7 @@ def _write_conne(
         cell_list.add(i)
 
     centers = np.array(centers)
+    centers = np.around(centers,decimals=4)
     int_points = np.array(int_points)
     int_normals = np.array(int_normals)
     bounds = np.array(bounds)


### PR DESCRIPTION
I created this pull request in regards to an issue I posted and fixed previously. This change fixes #139.

I made this change because depending on the specific mesh that users work with, without this change, users might end up with misleading results, without even realizing possibly. I used Gmsh to generate the mesh and brought it into toughio. The centroids of elements used internally in toughio pre-processing seem to consist of lots of decimal points (floating). Given way ISOT function is defined, the centroids must be exactly the same (with no tolerance in floating rounding, even in the range of 10^-5 or less) for the mask parameter defined in the ISOT function to result in only one single "False" value in each row of mask parameter. Otherwise, two "False" values in the same row will lead to ISOT of 1, even if the connections are vertical.

After this change, I managed to match the simulation results of anisotropic-permeability case between a case I created using toughio and another I created using a commercial pre-processor.



<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
